### PR TITLE
Add 0 to allowed package name characters

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreator.kt
@@ -35,7 +35,7 @@ class SourceJarCreator(
     private const val BL = """\p{Blank}*"""
     private const val COM_BL = """$BL(?:/\*[^\n]*\*/$BL)*"""
     private val PKG_PATTERN: Pattern =
-      Pattern.compile("""^${COM_BL}package$COM_BL([a-zA-Z1-9._]+)$COM_BL(?:;?.*)$""")
+      Pattern.compile("""^${COM_BL}package$COM_BL([a-zA-Z0-9._]+)$COM_BL(?:;?.*)$""")
 
     @JvmStatic
     fun extractPackage(line: String): String? =


### PR DESCRIPTION
For some unknown reason, `0` is the only alphanumeric character that wasn't recognized as in a package name. This led to odd scenarios that when you tried to compile code that had a `0` in the package name, the kotlin builder would package the code as the string before the `0` which led to some problems in auto-generated code.